### PR TITLE
Fix pagebreak anchors rendering

### DIFF
--- a/util/xslt/culiturgical.xsl
+++ b/util/xslt/culiturgical.xsl
@@ -73,7 +73,9 @@
 					<xsl:value-of select="@number"/>
 				</xsl:attribute>
 				<xsl:attribute name="href">http://www.ponomar.net/cgi-bin/bookpage.cgi?id=<xsl:value-of select="$bookId"/>&amp;page=<xsl:value-of select="@number"/></xsl:attribute>
-				<xsl:value-of select="@number"/>
+				<xsl:text>(л. </xsl:text>
+				<xsl:value-of select="@label"/>
+				<xsl:text>)</xsl:text>
 			</xsl:element>
 		</xsl:element>
 	</xsl:template>


### PR DESCRIPTION
This PR addresses Issue #36. Pagebreak anchor transformation rules are updated so that anchors render the same way as they appear in [Ponomar Library](https://www.ponomar.net/cgi-bin/bookreader2.cgi?uuid=7f39978b-bbc7-11e1-aa4b-ac670dfa6e4b).

An example of the fixed pagebreak anchor transformation output (indentation added for readability):

```
<small class="pb">
    <a title="folio 1v" href="http://www.ponomar.net/cgi-bin/bookpage.cgi?id=&amp;page=1v">
        (л. а҃ ѡ҆б.)
    </a>
</small>
```